### PR TITLE
Fix share status mismatch

### DIFF
--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -44,7 +44,7 @@ export interface SubscriptionShare {
   userId: string
   role: 'owner' | 'member'
   sharePercentage: number
-  status: 'pending' | 'active' | 'cancelled'
+  status: 'pending' | 'active' | 'declined' | 'removed'
   joinedAt?: string
   lastAccessedAt?: string
   permissions: SharePermissions

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -47,7 +47,7 @@ export interface SubscriptionShare {
   userId: string
   role: 'owner' | 'member'
   sharePercentage: number
-  status: 'pending' | 'active' | 'cancelled'
+  status: 'pending' | 'active' | 'declined' | 'removed'
   joinedAt?: string
   lastAccessedAt?: string
   permissions: SharePermissions
@@ -285,7 +285,8 @@ export type PaymentStatus = typeof PAYMENT_STATUSES[number]
 export const SHARE_STATUSES = [
   'pending',
   'active',
-  'cancelled'
+  'declined',
+  'removed'
 ] as const
 
 export type ShareStatus = typeof SHARE_STATUSES[number] 


### PR DESCRIPTION
## Summary
- update shared and frontend types to support `declined` and `removed` share states

## Testing
- `npx jest --passWithNoTests` in `packages/backend`
- `npx jest --passWithNoTests` in `packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_688c329b680c832293b4d87ddae2c34f